### PR TITLE
Fix configure to build on musl-based distributions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,19 @@
 language: c
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
-script: bash -ex .travis-opam.sh
-dist: trusty
+sudo: false
+services:
+  - docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
+script: bash ./.travis-docker.sh
 env:
-  - PACKAGE="xenctrl" OCAML_VERSION=4.01
-  - PACKAGE="xenctrl" OCAML_VERSION=latest
+ global:
+   - PACKAGE="xenctrl"
+ matrix:
+   - DISTRO=debian-stable OCAML_VERSION=4.01.0
+   - DISTRO=debian-testing OCAML_VERSION=4.02.3
+   - DISTRO=debian-unstable OCAML_VERSION=4.03.0
+#   - DISTRO=ubuntu-12.04 OCAML_VERSION=4.02.3
+   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.03.0
+#   - DISTRO=centos-7 OCAML_VERSION=4.02.3
+   - DISTRO=fedora-24 OCAML_VERSION=4.02.3
+   - DISTRO=alpine-3.4 OCAML_VERSION=4.03.0
+

--- a/configure
+++ b/configure
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-D=$(mktemp -d /tmp/configure.XXXXX)
+D=$(mktemp -d /tmp/configure.XXXXXX)
 function cleanup {
   cd /
   rm -rf $D

--- a/configure.ml
+++ b/configure.ml
@@ -146,7 +146,7 @@ let check_cores_per_socket verbose =
 
 
 let check_arm_header verbose =
-  let lines = run verbose "arch" in
+  let lines = run verbose "uname -m" in
   let arch = List.hd lines in
   let arm = String.length arch >= 3 && String.sub arch 0 3 = "arm" in
   if arm then begin

--- a/opam
+++ b/opam
@@ -28,7 +28,9 @@ depexts: [
   [["debian"] ["libxen-dev" "uuid-dev"]]
   [["ubuntu"] ["libxen-dev" "uuid-dev"]]
   [["centos"] ["xen-devel"]]
+  [["fedora"] ["xen-devel"]]
   [["xenserver"] ["xen-dom0-libs-devel" "xen-libs-devel"]]
+  [["alpine"] ["xen-dev"]]
 ]
 available: [ ocaml-version >= "4.00.0" ]
 


### PR DESCRIPTION
It is possible to build the library on alpine linux by using `uname -m` in place of `arch` (according to `GNU coreutils` sources they are exactly the same) and slightly modifying `mktemp`'s template. This PR fixes the issue (tested here: https://travis-ci.org/mseri/ocaml-xen-lowlevel-libs/builds/165262513)
